### PR TITLE
Issue #146 Avoid uncaught exception when handling failure case in expiring-value

### DIFF
--- a/expiring-value/lib/expiring-value.ts
+++ b/expiring-value/lib/expiring-value.ts
@@ -35,8 +35,8 @@ export class ExpiringValue<T> {
             if (this.options.cacheError) {
                 this.extendExpiration();
             } else {
-                // Update expiration, only upon success
-                this.value.then(() => this.extendExpiration());
+                // Update expiration, only upon success; no-op on error here
+                this.value.then(() => this.extendExpiration()).catch(() => undefined);
             }
         }
 

--- a/expiring-value/package.json
+++ b/expiring-value/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "tsc && npm link && cp dist/expiring-value.d.ts ../docs/types/",
-    "test": "NODE_OPTIONS=--unhandled-rejections=none jest",
+    "test": "jest",
     "test:watch": "jest --watch",
     "clean:publish": "rm -r dist; npm run build && npm publish --access public"
   },


### PR DESCRIPTION
Prevents uncaught exception scenario when the factory function throws and we are not caching the failure.

This is a bug introduced by the previous implementation for issue #146.
